### PR TITLE
[Fix] Official GitHub MCP Registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubnub/mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "mcpName": "io.github.pubnub/mcp-server",
   "description": "PubNub Model Context Protocol MCP Server for Cursor and Claude",
   "main": "dist/index.js",
@@ -17,7 +17,7 @@
   "keywords": [
     "PubNub",
     "LLM",
-    "MPC",
+    "MCP",
     "Model Context Protocol"
   ],
   "files": [

--- a/server.json
+++ b/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.pubnub/mcp",
+  "name": "io.github.pubnub/mcp-server",
   "title": "PubNub MCP Server",
   "description": "PubNub Model Context Protocol MCP Server for Cursor and Claude",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "url": "https://github.com/pubnub/pubnub-mcp-server",
     "source": "github"


### PR DESCRIPTION

<img width="1270" height="773" alt="Screenshot 2026-02-02 at 6 53 13 PM" src="https://github.com/user-attachments/assets/0a9295d4-f184-415a-90dc-d93cbc86f9b7" />


Fix for MCP Registry configuration to enable server discovery and verification.

## Fixes

| File | Line | Issue | Before | After |
|------|------|-------|--------|-------|
| `server.json` | 3 | Name mismatch with `mcpName` in package.json | `io.github.pubnub/mcp` | `io.github.pubnub/mcp-server` |
| `package.json` | 20 | Typo in keywords | `MPC` | `MCP` |

## Why This Matters

- **Registry Verification**: The `name` in `server.json` must match `mcpName` in `package.json` for the MCP registry to verify and list the server correctly

## Verification

After merging, publish and verify:
```bash
mcp-publisher login github
mcp-publisher publish
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.pubnub/mcp-server"
```


