### PR TITLE
Fix objective-c subscribe feature name in SDK schema

### DIFF
--- a/src/lib/docs/schemas.ts
+++ b/src/lib/docs/schemas.ts
@@ -233,7 +233,7 @@ export const sdkLanguageToFeatures = {
     "publish-methods",
     "storage-and-playback-builder",
     "storage-and-playback-methods",
-    "subscribe",
+    "subscribe-methods",
   ],
   php: [
     "access-manager",


### PR DESCRIPTION
Change objective-c SDK feature from "subscribe" to "subscribe-methods" to match the correct documentation endpoint.