### PR TITLE
Fix objective-c subscribe feature name in SDK docs

### DIFF
--- a/src/lib/docs/schemas.ts
+++ b/src/lib/docs/schemas.ts
@@ -233,7 +233,7 @@ export const sdkLanguageToFeatures = {
     "publish-methods",
     "storage-and-playback-builder",
     "storage-and-playback-methods",
-    "subscribe-methods",
+    "subscribe",
   ],
   php: [
     "access-manager",


### PR DESCRIPTION
Rename "subscribe-methods" to "subscribe" for objective-c language in the SDK language-to-features mapping because of the documentation changes.