### PR TITLE
Remove outdated _memberships, _spaces, _users docs from SDK schema

### DIFF
--- a/src/lib/docs/schemas.test.ts
+++ b/src/lib/docs/schemas.test.ts
@@ -22,10 +22,10 @@ describe("Docs Schemas", () => {
     });
 
     it("should reject feature not supported by specific language", () => {
-      // javascript doesn't have '_users' feature
+      // javascript doesn't have 'publish-builder' feature (only objective-c does)
       const invalidData = {
         language: "javascript",
-        feature: "_users",
+        feature: "publish-builder",
       };
 
       const result = GetSdkDocumentationSchemaRefined.safeParse(invalidData);

--- a/src/lib/docs/schemas.ts
+++ b/src/lib/docs/schemas.ts
@@ -178,9 +178,6 @@ export const sdkLanguageToFeatures = {
     "subscribe",
   ],
   kotlin: [
-    "_memberships",
-    "_spaces",
-    "_users",
     "access-manager",
     "access-manager-v2",
     "appcontext-channel",
@@ -274,9 +271,6 @@ export const sdkLanguageToFeatures = {
     "subscribe",
   ],
   python: [
-    "_memberships",
-    "_spaces",
-    "_users",
     "access-manager",
     "access-manager-v2",
     "appcontext-channel",


### PR DESCRIPTION
These legacy features are outdated and should no longer be exposed through the MCP server. Removes them from kotlin and python language mappings and updates the related test.