### PR TITLE
Distinguish python-sync and python-asyncio SDK docs

### DIFF
--- a/src/lib/docs/api.test.ts
+++ b/src/lib/docs/api.test.ts
@@ -35,9 +35,76 @@ describe("Docs API", () => {
 
   describe("getSdkDocumentation", () => {
     it("should fetch SDK documentation successfully", async () => {
-      const result = await getSdkDocumentation("python", "configuration");
+      const result = await getSdkDocumentation("javascript", "publish");
 
       expect(result).toEqual(mockSdkDocumentation);
+    });
+
+    it("should include sync python hint when language is `python-sync`", async () => {
+      const result = await getSdkDocumentation("python-sync", "configuration");
+
+      expect(result).toEqual({
+        ...mockSdkDocumentation,
+        hint: "IMPORTANT: This is the SYNCHRONOUS Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!",
+      });
+    });
+
+    it("should include async python hint when language is `python-asyncio`", async () => {
+      const result = await getSdkDocumentation("python-asyncio", "configuration");
+
+      expect(result).toEqual({
+        ...mockSdkDocumentation,
+        hint: "IMPORTANT: This is the ASYNCHRONOUS (asyncio) Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!",
+      });
+    });
+
+    it("should not include a hint for non python/asyncio languages", async () => {
+      const result = await getSdkDocumentation("javascript", "publish");
+
+      expect(result).not.toHaveProperty("hint");
+    });
+
+    it("should call the docs API with `python` when public language is `python-sync`", async () => {
+      const capturedUrls: string[] = [];
+      overrideDocsRoute("get", "/sdk", ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json(mockSdkDocumentation);
+      });
+
+      await getSdkDocumentation("python-sync", "configuration");
+
+      expect(capturedUrls).toHaveLength(1);
+      const url = new URL(capturedUrls[0] as string);
+      expect(url.searchParams.get("language")).toBe("python");
+      expect(url.searchParams.get("feature")).toBe("configuration");
+    });
+
+    it("should call the docs API with `asyncio` when public language is `python-asyncio`", async () => {
+      const capturedUrls: string[] = [];
+      overrideDocsRoute("get", "/sdk", ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json(mockSdkDocumentation);
+      });
+
+      await getSdkDocumentation("python-asyncio", "configuration");
+
+      expect(capturedUrls).toHaveLength(1);
+      const url = new URL(capturedUrls[0] as string);
+      expect(url.searchParams.get("language")).toBe("asyncio");
+      expect(url.searchParams.get("feature")).toBe("configuration");
+    });
+
+    it("should not translate languages that are not Python ecosystem aliases", async () => {
+      const capturedUrls: string[] = [];
+      overrideDocsRoute("get", "/sdk", ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json(mockSdkDocumentation);
+      });
+
+      await getSdkDocumentation("javascript", "publish");
+
+      const url = new URL(capturedUrls[0] as string);
+      expect(url.searchParams.get("language")).toBe("javascript");
     });
 
     it("should throw error on HTTP error response", async () => {

--- a/src/lib/docs/api.ts
+++ b/src/lib/docs/api.ts
@@ -60,13 +60,26 @@ async function makeDocsRequest<T>({
   return (await response.json()) as DocumentationApiResponse;
 }
 
+const pythonEcosystemHints: Partial<Record<GetSdkDocumentationSchemaType["language"], string>> = {
+  "python-sync":
+    "IMPORTANT: This is the SYNCHRONOUS Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!",
+  "python-asyncio":
+    "IMPORTANT: This is the ASYNCHRONOUS (asyncio) Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!",
+};
+
+const sdkLanguageApiAliases: Partial<Record<GetSdkDocumentationSchemaType["language"], string>> = {
+  "python-sync": "python",
+  "python-asyncio": "asyncio",
+};
+
 export async function getSdkDocumentation(
   language: GetSdkDocumentationSchemaType["language"],
   feature: GetSdkDocumentationSchemaType["feature"]
 ) {
-  const path = `/sdk?feature=${feature}&language=${language}`;
+  const apiLanguage = sdkLanguageApiAliases[language] ?? language;
+  const path = `/sdk?feature=${feature}&language=${apiLanguage}`;
 
-  return await makeDocsRequest<GetSdkDocumentationSchemaType>({
+  const response = await makeDocsRequest<GetSdkDocumentationSchemaType>({
     path,
     schema: GetSdkDocumentationSchemaRefined,
     args: {
@@ -74,6 +87,13 @@ export async function getSdkDocumentation(
       feature,
     },
   });
+
+  const hint = pythonEcosystemHints[language];
+  if (hint) {
+    return { ...response, hint };
+  }
+
+  return response;
 }
 
 export async function getChatSdkDocumentation(

--- a/src/lib/docs/handlers.test.ts
+++ b/src/lib/docs/handlers.test.ts
@@ -36,6 +36,34 @@ describe("Docs Handlers", () => {
       expect(parsedText.metadata.title).toBe("Publish and Subscribe - JavaScript SDK");
     });
 
+    it("should include the sync hint for python", async () => {
+      const args = { language: "python-sync" as const, feature: "configuration" as const };
+      const result = await getSDKDocumentationHandler(args);
+
+      const parsedText = JSON.parse(result.content?.[0]?.text ?? "{}");
+      expect(parsedText.hint).toBe(
+        "IMPORTANT: This is the SYNCHRONOUS Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!"
+      );
+    });
+
+    it("should include the async hint for asyncio", async () => {
+      const args = { language: "python-asyncio" as const, feature: "configuration" as const };
+      const result = await getSDKDocumentationHandler(args);
+
+      const parsedText = JSON.parse(result.content?.[0]?.text ?? "{}");
+      expect(parsedText.hint).toBe(
+        "IMPORTANT: This is the ASYNCHRONOUS (asyncio) Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!"
+      );
+    });
+
+    it("should not include a hint for non python/asyncio languages", async () => {
+      const args = { language: "javascript" as const, feature: "publish" as const };
+      const result = await getSDKDocumentationHandler(args);
+
+      const parsedText = JSON.parse(result.content?.[0]?.text ?? "{}");
+      expect(parsedText.hint).toBeUndefined();
+    });
+
     it("should handle API error", async () => {
       overrideDocsResponse(
         "get",
@@ -112,6 +140,30 @@ describe("Docs Handlers", () => {
       const parsedContent = JSON.parse(content?.text ?? "{}");
       expect(parsedContent.content).toBeDefined();
       expect(parsedContent.metadata).toBeDefined();
+    });
+
+    it("should expose the python sync hint in the resource payload", async () => {
+      const uri = new URL("pubnub-docs://sdk/python-sync/configuration");
+      const args = { language: "python-sync" as const, feature: "configuration" as const };
+
+      const result = await getSDKDocumentationResourceHandler(uri, args);
+
+      const parsedContent = JSON.parse(result.contents?.[0]?.text ?? "{}");
+      expect(parsedContent.hint).toBe(
+        "IMPORTANT: This is the SYNCHRONOUS Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!"
+      );
+    });
+
+    it("should expose the asyncio async hint in the resource payload", async () => {
+      const uri = new URL("pubnub-docs://sdk/python-asyncio/configuration");
+      const args = { language: "python-asyncio" as const, feature: "configuration" as const };
+
+      const result = await getSDKDocumentationResourceHandler(uri, args);
+
+      const parsedContent = JSON.parse(result.contents?.[0]?.text ?? "{}");
+      expect(parsedContent.hint).toBe(
+        "IMPORTANT: This is the ASYNCHRONOUS (asyncio) Python SDK. Before answering or generating code, ALWAYS ask the customer to confirm whether they need the sync (python-sync) or async (python-asyncio) version of the SDK, then use the matching Resource!"
+      );
     });
 
     it("should throw error for missing language", async () => {

--- a/src/lib/docs/schemas.ts
+++ b/src/lib/docs/schemas.ts
@@ -48,19 +48,6 @@ function createLanguageFeatureSchemas<TMapping extends Record<string, readonly s
 }
 
 export const sdkLanguageToFeatures = {
-  asyncio: [
-    "access-manager",
-    "channel-groups",
-    "configuration",
-    "files",
-    "message-actions",
-    "misc",
-    "mobile-push",
-    "presence",
-    "publish",
-    "storage-and-playback",
-    "subscribe",
-  ],
   "c-core": [
     "access-manager",
     "channel-groups",
@@ -262,7 +249,20 @@ export const sdkLanguageToFeatures = {
     "storage-and-playback",
     "subscribe",
   ],
-  python: [
+  "python-asyncio": [
+    "access-manager",
+    "channel-groups",
+    "configuration",
+    "files",
+    "message-actions",
+    "misc",
+    "mobile-push",
+    "presence",
+    "publish",
+    "storage-and-playback",
+    "subscribe",
+  ],
+  "python-sync": [
     "access-manager",
     "appcontext-channel",
     "appcontext-members",

--- a/src/lib/docs/types.ts
+++ b/src/lib/docs/types.ts
@@ -26,4 +26,5 @@ export type DocumentationApiResponse = {
     source_url: string;
     updated_at: string;
   };
+  hint?: string;
 };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -158,6 +158,7 @@ const getSDKDocumentationTool: ToolDef<GetSdkDocumentationSchemaType> = {
       - Need fine-grained control over pub/sub, presence, storage, or access management
       - Implementing custom real-time patterns
       - Need API reference for specific SDK methods (publish, subscribe, history, etc.)
+      - For Python SDK usage always request about sync or asyncio version of langauge. 
 
       **Do NOT use for:**
       - Chat/messaging apps → use "get_chat_sdk_documentation" instead


### PR DESCRIPTION
Renames the Python SDK enum values exposed to LLMs to `python-sync` and `python-asyncio` so the two variants can be told apart at a glance, while keeping the docs API path unchanged (`python` and `asyncio`) through an internal alias map in `getSdkDocumentation`.

The SDK documentation response now also includes a `hint` field for both Python variants instructing the LLM to always ask the customer which version of the SDK they want before answering or generating code.

The Core SDK tool description gains a matching note so the directive is visible at tool-selection time as well.